### PR TITLE
Bug fix for text expander and new text contractor function

### DIFF
--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -7,6 +7,7 @@ module_path = Path(__file__).parent.parent.absolute()
 
 cdf = pd.read_csv(os.path.join(module_path, "data/georgian_contractions.csv"))
 cmap = cdf.set_index('CONTRACTION')[['EXPANSION']].to_dict('dict')['EXPANSION']
+emap = cdf.set_index('EXPANSION')[['CONTRACTION']].to_dict('dict')['CONTRACTION']
 
 def expand(word):
     # Just a wrapper around contractions map
@@ -19,8 +20,8 @@ def expand(word):
 def expand_text(text):
     # Look up contractions sequentially and replace them with expansions
     while True:
-        match = re.search(r'[ა-ჿ]+\.', text)
-        if bool(match) == False:
+        match = re.search(r'([ა-ჿ]+\.(?:[ა-ჿ]+\.)*)', text)
+        if not bool(match):
             break
 
         expansion = expand(text[match.start():match.end()])
@@ -28,3 +29,8 @@ def expand_text(text):
 
     return text
 
+
+def contract_text(text):
+    for key in emap.keys():
+        text = re.sub(key, emap[key], text)
+    return text

--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -19,14 +19,9 @@ def expand(word):
 
 def expand_text(text):
     # Look up contractions sequentially and replace them with expansions
-    while True:
-        match = re.search(r'([ა-ჿ]+\.(?:[ა-ჿ]+\.)*)', text)
-        if not bool(match):
-            break
-
-        expansion = expand(text[match.start():match.end()])
-        text = text[:match.start()] + expansion + text[match.end():]
-
+    matches = re.findall(r'([ა-ჿ]+\.(?:[ა-ჿ]+\.)*)', text)
+    for match in matches:
+       text = re.sub(match, expand(match), text)
     return text
 
 


### PR DESCRIPTION
Updated the regex pattern in `expand_text` function to correctly handle abbreviations with multiple commas, such as `ჩ.წ.ა`.
The new implementation also accounts for abbreviations not found in the data file.
Previously such abbreviations would cause the function to run indefinitely.

Of note - this doesn't account for abbreviations with spaces in them, such as `ძვ. სტ.`. In this specific example, it would get expanded to "ძველი სტამბა" since those are the expansions of those two respective contractions. 
Probably the only way to fix this would be to loop through each contraction and look them up individually, similar to how the newly implemented `contract_text` works.

New functionality example:
```from anbani.nlp.contractions import expand_text, contract_text

text = "ილია ჭავჭავაძე (დ. 8 ნოემბერი, 1837, სოფელი ყვარელი — გ. 12 სექტემბერი, 1907, წიწამური; მ.ა.ე. ას.ს.წს. ძვ. სტ.)"

print(text)
expanded_text = expand_text(text)
print(expanded_text)
print(contract_text(expanded_text))

# ილია ჭავჭავაძე (დ. 8 ნოემბერი, 1837, სოფელი ყვარელი — გ. 12 სექტემბერი, 1907, წიწამური; მ.ა.ე. ას.ს.წს. ძვ. სტ.)
# ილია ჭავჭავაძე (დაბადება 8 ნოემბერი, 1837, სოფელი ყვარელი — გარდაცვალება 12 სექტემბერი, 1907, წიწამური; მასის ატომური ერთეული ას.ს.წს. ძველი სტამბა)
# ილია ჭავჭავაძე (დაბ. 8 ნოემბ., 1837, სოფ. ყვარელი — გარდ. 12 სექ., 1907, წიწამური; მ.ა.ე. ას.ს.წს. ძვ. სტ.)
```