### PR TITLE
Converter fixes + nlp test coverage (92%), slimmer deps, coverage/publish CI, badges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+# Publishes to PyPI when a GitHub Release is published.
+#
+# One-time setup (no API token needed — uses OIDC "trusted publishing"):
+#   1. On https://pypi.org/manage/project/anbani/settings/publishing/ add a
+#      trusted publisher: owner "Anbani", repo "anbani.py", workflow
+#      "publish.yml", environment left blank.
+#   2. Create a GitHub Release to trigger this workflow.
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install (converter deps only)
+        # The converter needs only hjson. The nlp subpackage's heavy optional
+        # deps (pymupdf, pandas, numpy, tqdm) are deliberately skipped to keep
+        # this signal fast and focused on anbani.core.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --no-deps
+          pip install hjson pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install (converter deps only)
-        # The converter needs only hjson. The nlp subpackage's heavy optional
-        # deps (pymupdf, pandas, numpy, tqdm) are deliberately skipped to keep
-        # this signal fast and focused on anbani.core.
+      - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install -e . --no-deps
-          pip install hjson pytest
+          pip install -e ".[pdf,dev]"
 
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: pytest --cov --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # AnbaniPy
 
+[![tests](https://github.com/Anbani/anbani.py/actions/workflows/test.yml/badge.svg)](https://github.com/Anbani/anbani.py/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/Anbani/anbani.py/branch/main/graph/badge.svg)](https://codecov.io/gh/Anbani/anbani.py)
+[![PyPI](https://img.shields.io/pypi/v/anbani)](https://pypi.org/project/anbani/)
+[![Python versions](https://img.shields.io/pypi/pyversions/anbani)](https://pypi.org/project/anbani/)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+
 Georgian Python toolkit for NLP, Transliteration and more. Partially based on [anbani.js](https://github.com/anbani/anbani.js).  
 
 ## Install
 
 ```bash
 pip install anbani
+```
+
+Transliteration and NLP utilities need only `hjson`. PDF / e-book extraction
+(`anbani.nlp.utils.ebook2text`) additionally requires PyMuPDF:
+
+```bash
+pip install anbani[pdf]
 ```
 
 ## Quickstart

--- a/anbani/__init__.py
+++ b/anbani/__init__.py
@@ -1,3 +1,7 @@
-# from .anbani import *
-# from .nlp import *
-# from .core import *
+# Lightweight public API. The `nlp` subpackage is intentionally NOT imported
+# here so that `import anbani` stays cheap and free of heavy optional
+# dependencies (PyMuPDF, pandas, numpy). Import it explicitly when needed:
+#     from anbani.nlp.georgianisation import georgianise
+from .core.converter import classify_text, convert, interpret
+
+__all__ = ["convert", "interpret", "classify_text"]

--- a/anbani/core/converter.py
+++ b/anbani/core/converter.py
@@ -1,15 +1,17 @@
-import hjson
-import re
 import os
+import re
+
+import hjson
 
 dirname = os.path.dirname(__file__)
 datafilepath = os.path.realpath(os.path.join(dirname, "../data/letters.js"))
 
-# Exact copy of the Javascript object from Anbani.JS for easier parallel development down the road
-# .js because .json doesn't allow comments that would be parsable with hjson (human json)
-data = hjson.loads(
-    open(datafilepath).read().replace('export default ', '')
-)
+# Exact copy of the Javascript object from Anbani.JS for easier parallel
+# development. It is a `.js` (not `.json`) file so it can carry comments, which
+# hjson (human json) tolerates. Keep it byte-identical to
+# anbani.js/src/lib/data.mjs so both libraries share a single source of truth.
+with open(datafilepath, encoding="utf-8") as _f:
+    data = hjson.loads(_f.read().replace("export default ", ""))
 
 script_regex = {
     "mkhedruli": "[ა-ჿ]",
@@ -17,111 +19,108 @@ script_regex = {
     "asomtavruli": "[Ⴀ-Ⴥ]",
     "nuskhuri": "[ⴀ-ⴥ]",
     "latin": "[a-zA-Z]",
-    "cyrillic": "[А-Яа-я]"
+    "cyrillic": "[А-Яа-я]",
+}
+
+# Scripts usable as a conversion *source* (i.e. that index 1:1 into the table).
+VALID_SOURCES = ("mkhedruli", "mtavruli", "asomtavruli", "nuskhuri", "qwerty")
+
+# Bicameral scripts pair an upper-case and a lower-case unicameral script.
+BICAMERAL_RULES = {
+    "sasataure":     {"upper": "asomtavruli", "lower": "mtavruli"},
+    "tfileliseuli":  {"upper": "mtavruli",    "lower": "mkhedruli"},
+    "shanidziseuli": {"upper": "asomtavruli", "lower": "mkhedruli"},
+    "khutsuri":      {"upper": "asomtavruli", "lower": "nuskhuri"},
+}
+
+# Deprecated / classifier-side script names mapped to their canonical name.
+SCRIPT_ALIASES = {
+    "anbanismtavruli": "sasataure",  # historical placeholder, kept for back-compat
+    "latin": "qwerty",               # what classify_text() reports for Latin input
 }
 
 
 # Single entrypoint for both bicameral and unicameral conversion
 def convert(text, dir_from, dir_to):
-    assert dir_from in [
-        'mkhedruli',
-        'mtavruli',
-        'asomtavruli',
-        'nuskhuri',
-        'qwerty',
-    ]
+    dir_from = SCRIPT_ALIASES.get(dir_from, dir_from)
+    dir_to = SCRIPT_ALIASES.get(dir_to, dir_to)
 
-    if dir_to in [
-        "anbanismtavruli",
-        "shanidziseuli",
-        "tfileliseuli",
-        "khutsuri",
-    ]:
+    if dir_from not in VALID_SOURCES:
+        raise ValueError(
+            f"Unsupported source script {dir_from!r}; "
+            f"expected one of {VALID_SOURCES}."
+        )
+
+    if dir_to in BICAMERAL_RULES:
         return convert_bicameral(text, dir_from, dir_to)
-    else:
-        return convert_unicameral(text, dir_from, dir_to)
+
+    if dir_to not in data["alphabets"]:
+        raise ValueError(
+            f"Unsupported target script {dir_to!r}; expected a bicameral script "
+            f"{tuple(BICAMERAL_RULES)} or one of {tuple(data['alphabets'])}."
+        )
+
+    return convert_unicameral(text, dir_from, dir_to)
 
 
-# Source text script automatching, handy for automatic keyboards and etc
+# Source-script automatching, handy for automatic keyboards etc.
 def interpret(text, dir_to):
     dir_from = classify_text(text)
+    if dir_from == "unknown":
+        raise ValueError("Could not detect the source script of the given text.")
     return convert(text, dir_from, dir_to)
 
 
 # Loose script classifier
-# TODO perhaps I should match with Anbani.JS vector matching or smth else entirely
 def classify_text(text):
-    for key in script_regex.keys():
-        if re.compile(script_regex[key]).match(text):
+    for key, pattern in script_regex.items():
+        # `search`, not `match`: the script may not start at position 0
+        # (e.g. leading whitespace, quotes or digits).
+        if re.search(pattern, text):
             return key
-
-    return 'unknown'
+    return "unknown"
 
 
 # Unicameral conversion
 def convert_unicameral(text, dir_from, dir_to):
-    return ''.join(map(
-        lambda letter : letter_converter(
-            letter, 
-            dir_from, 
-            dir_to
-        ),
-        text
-    ))
+    return "".join(letter_converter(letter, dir_from, dir_to) for letter in text)
 
 
-# Bicameral conversion of Georgian texts. 
-# "'anbanismtavruli' is just a temp name for now "- said George ages ago. 
-# TODO come up with a better name hopefully with historical precedent. 
+# Bicameral conversion of Georgian texts.
 def convert_bicameral(text, dir_from, dir_to):
-    rules = {
-        "anbanismtavruli": {
-            "upper": "asomtavruli",
-            "lower": "mtavruli",
-        },
-        "tfileliseuli": {
-            "upper": "mtavruli",
-            "lower": "mkhedruli",
-        },
-        "shanidziseuli": {
-            "upper": "asomtavruli",
-            "lower": "mkhedruli",
-        },
-        "khutsuri": {
-            "upper": "asomtavruli",
-            "lower": "nuskhuri",
-        },
-    }
+    if not text:
+        return ""
 
-    upper_script = rules[dir_to]['upper']
-    lower_script = rules[dir_to]['lower']
+    upper_script = BICAMERAL_RULES[dir_to]["upper"]
+    lower_script = BICAMERAL_RULES[dir_to]["lower"]
 
-    # Convert first letter
-    converted = letter_converter(
-        text[0], dir_from, upper_script
-    ) + convert_unicameral(text[1:], dir_from, lower_script)
+    # First letter to the upper-case script, the remainder to the lower-case one
+    converted = list(
+        letter_converter(text[0], dir_from, upper_script)
+        + convert_unicameral(text[1:], dir_from, lower_script)
+    )
 
-    # Convert first letter after every sentence
-    matched = re.finditer(r'[?.!჻]\s+[A-zა-ჿႠ-Ⴥⴀ-ⴥᲐ-Ჿ0-9]', converted)
-    converted = list(converted)
-    for match in matched:
-        converted[match.end()-1] = letter_converter(
-            converted[match.end()-1], lower_script, upper_script
+    # Upper-case the first letter after every sentence terminator
+    for match in re.finditer(
+        r"[?.!჻]\s+[A-Za-zა-ჿႠ-Ⴥⴀ-ⴥᲐ-Ჿ0-9]", "".join(converted)
+    ):
+        converted[match.end() - 1] = letter_converter(
+            converted[match.end() - 1], lower_script, upper_script
         )
 
-    # Convert first letter before every special letter
-    matched = re.finditer(r'[ა-ჿႠ-Ⴥⴀ-ⴥᲐ-Ჿ]\'', ''.join(converted))
-    for match in matched:
+    # Upper-case a letter explicitly marked with a trailing apostrophe
+    for match in re.finditer(r"[ა-ჿႠ-Ⴥⴀ-ⴥᲐ-Ჿ]'", "".join(converted)):
         converted[match.start()] = letter_converter(
             converted[match.start()], lower_script, upper_script
         )
-        converted[match.start()+1] = ''
+        converted[match.start() + 1] = ""
 
-    return ''.join(converted)
+    return "".join(converted)
 
 
 def letter_converter(letter, dir_from, dir_to):
-    try: return data['alphabets'][dir_to][
-        data['alphabets'][dir_from].index(letter)
-    ]
-    except: return letter
+    try:
+        return data["alphabets"][dir_to][data["alphabets"][dir_from].index(letter)]
+    except ValueError:
+        # Letter not present in the source alphabet (punctuation, spaces, …)
+        return letter

--- a/anbani/data/letters.js
+++ b/anbani/data/letters.js
@@ -13,6 +13,7 @@ export default {
             "ა-უმლაუტი", "ა-მაკრონი", "ა-მაკრონ-უმლაუტი", "ე-მაკრონი", "ი-მაკრონი",
             "ო-უმლაუტი", "ო-მაკრონი", "ო-მაკრონ-უმლაუტი", "უ-უმლაუტი", "უ-მაკრონი",
             "უ-მაკრონ-უმლაუტი", "უ-ბრჯგუ", "ჷნ-მაკრონი",
+            "წერტილი", "მძიმე", "კითხვის ნიშანი", "ძახილის ნიშანი", "წერტილ-მძიმე", "ორწერტილი",
 
         ],
 
@@ -27,7 +28,10 @@ export default {
             "ა̈", "ა̄", "ა̄̈", "ე̄", "ი̄",
             "ო̈", "ო̄", "ო̄̈", "უ̈", "უ̄",
             "უ̄̈", "უ̂", "ჷ̄",
+            ".", ",", "?", "!", ";", ":",
+
         ],
+
 
         // Modern unicameral derivative script of Mkhedruli only used for headlines in all-caps
         mtavruli: [
@@ -40,6 +44,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Original Georgian alphabet from 5th century
@@ -53,6 +59,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Second script of Georgian alphabet first appearing in 9th century
@@ -66,6 +74,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Collection of letters from all around the world that resemble Mkhedruli
@@ -79,6 +89,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Zalgo crazy text using diacritics
@@ -95,6 +107,22 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
+        ],
+
+        // Braille https://en.wikipedia.org/wiki/Georgian_Braille
+        braille: [
+            "⠁", "⠃", "⠛", "⠙", "⠑", "⠺", "⠵", "⠋", "⠊", "⠅", "⠇",
+            "⠍", "⠝", "⠕", "⠏", "⠚", "⠗", "⠎", "⠞", "⠥", "⠧", "⠻",
+            "⠫", "⠮", "⠱", "⠟", "⠉", "⠽", "⠹", "⠭", "⠓", "⠪", "⠯",
+            "", "", "", "", "",
+            "", "", "", "", "",
+            "⠌", "", "", "", "",
+            "", "", "", "", "",
+            "", "", "", "", "",
+            "", "", "",
+            "⠲", "⠂", "⠦", "⠖", "⠆", "⠒",
         ],
 
         // Commonly adopted romanization as seen on social media
@@ -108,6 +136,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Georgian alphabet cyrillization 
@@ -121,6 +151,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Georgian alphabet hellenization 
@@ -134,6 +166,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Georgian alphabet armenianization 
@@ -147,6 +181,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // International Standards Organization (http://www.iso.ch) as shown in Apridonidze et al. and UNGEGN
@@ -160,6 +196,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         //  The national system of romanization adopted in February 2002 by the State Department of Geodesy and Cartography of Georgia and the Institute of Linguistics, Georgian Academy of Sciences
@@ -173,6 +211,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Iberiul-K’avk’asiuri enatmetsnierebis ts’elits’deuli [Annual of Ibero-Caucasian Linguistics] as shown in The World’s Writing Systems. Variant forms separated with a slash
@@ -196,10 +236,24 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
-        // Thesaurus Indogermanischer Text- und Sprachmaterialien (http://titus.uni-frankfurt.de)
-        // titus : []
+        // The transliterating system TITUS was introduced by the journal "Georgika" in Jena and was adapted by Jost Gippert for TITUS (https://titus.uni-frankfurt.de/).
+        titus : [
+            "a", "b", "g", "d", "e", "v", "z", "t", "i", "ḳ", "l", 
+            "m", "n", "o", "ṗ", "ž", "r", "s", "ṭ", "u", "p", "k", 
+            "ġ", "q̇", "š", "č", "c", "ӡ", "c̣", "č̣", "x", "ǯ", "h", 
+            "ē", "y", "w", "q", "ō",
+            "", "", "", "", "",
+            "", "", "", "", "",
+            "", "", "", "", "",
+            "", "", "", "", "",
+            "", "", "",     
+            ".", ",", "?", "!", ";", ":",
+
+        ],
 
         // Latin to Georgian QWERTY keyboard mapping used for older fonts
         qwerty: [
@@ -212,6 +266,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // Numeric values
@@ -225,6 +281,8 @@ export default {
             "", "", "", "", "",
             "", "", "", "", "",
             "", "", "",
+            ".", ",", "?", "!", ";", ":",
+
         ],
 
         // See also http://transliteration.eki.ee/pdf/Georgian.pdf

--- a/anbani/nlp/__init__.py
+++ b/anbani/nlp/__init__.py
@@ -1,1 +1,8 @@
-from . import *
+"""Natural-language utilities for Georgian.
+
+Import the submodules directly, e.g.::
+
+    from anbani.nlp.georgianisation import georgianise
+    from anbani.nlp.preprocessing import word_tokenize
+    from anbani.nlp.contractions import expand_text
+"""

--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -1,30 +1,29 @@
-import pandas as pd
+import csv
 import os
-import re
 from pathlib import Path
 
 module_path = Path(__file__).parent.parent.absolute()
 
-cdf = pd.read_csv(os.path.join(module_path, "data/georgian_contractions.csv"))
-cmap = cdf.set_index('CONTRACTION')[['EXPANSION']].to_dict('dict')['EXPANSION']
+with open(
+    os.path.join(module_path, "data/georgian_contractions.csv"),
+    encoding="utf-8",
+    newline="",
+) as _f:
+    cmap = {row["CONTRACTION"]: row["EXPANSION"] for row in csv.DictReader(_f)}
+
+# Replace longest contractions first so that e.g. "ა.ს.ს.რ." is handled before
+# the shorter "ა." that it contains.
+_contractions_by_length = sorted(cmap.items(), key=lambda kv: len(kv[0]), reverse=True)
+
 
 def expand(word):
-    # Just a wrapper around contractions map
-    if word in cmap:
-        return cmap[word]
-
-    return word
+    # Just a wrapper around the contractions map
+    return cmap.get(word, word)
 
 
 def expand_text(text):
-    # Look up contractions sequentially and replace them with expansions
-    while True:
-        match = re.search(r'[ა-ჿ]+\.', text)
-        if bool(match) == False:
-            break
-
-        expansion = expand(text[match.start():match.end()])
-        text = text[:match.start()] + expansion + text[match.end():]
+    # Replace every known contraction with its expansion.
+    for contraction, expansion in _contractions_by_length:
+        text = text.replace(contraction, expansion)
 
     return text
-

--- a/anbani/nlp/georgianisation.py
+++ b/anbani/nlp/georgianisation.py
@@ -1,17 +1,27 @@
-import pandas as pd
-import re
+import csv
 import os
+import re
 from pathlib import Path
+
 module_path = Path(__file__).parent.parent.absolute()
 
 
 AMBIGRAM_BALANCED_PATH = os.path.join(module_path, "data/ambigram_nc5_len7.csv")
 AMBIGRAM_ACCURATE_PATH = os.path.join(module_path, "data/ambigram_nc1_len10.csv")
 
-extract_mapping = lambda df: df[~df.REDUNDANT][["MASKED", "NGRAM"]].values
 
-ambigrams_balanced = extract_mapping(pd.read_csv(AMBIGRAM_BALANCED_PATH))
-ambigrams_accurate = extract_mapping(pd.read_csv(AMBIGRAM_ACCURATE_PATH))
+def _load_ambigrams(path):
+    """Load (MASKED -> NGRAM) substitution pairs, skipping redundant rows."""
+    with open(path, encoding="utf-8", newline="") as f:
+        return [
+            (row["MASKED"], row["NGRAM"])
+            for row in csv.DictReader(f)
+            if row["REDUNDANT"].strip().lower() != "true"
+        ]
+
+
+ambigrams_balanced = _load_ambigrams(AMBIGRAM_BALANCED_PATH)
+ambigrams_accurate = _load_ambigrams(AMBIGRAM_ACCURATE_PATH)
 
 
 diphthong_mapping = [

--- a/anbani/nlp/utils.py
+++ b/anbani/nlp/utils.py
@@ -1,40 +1,68 @@
-import pandas as pd
-from tqdm import tqdm
-import re
-from collections import defaultdict
-import fitz
+"""PDF / e-book text extraction.
+
+PyMuPDF is imported lazily inside :func:`ebook2text` so that importing this
+module (and the rest of ``anbani.nlp``) does not require the optional
+``pymupdf`` dependency.
+"""
+
+# Hyphen-like code points that, when followed by a newline, indicate a word
+# split across lines and should be stitched back together.
+_HYPHENS = (
+    "-",   # 002D
+    "‐",   # 2010
+    "‑",   # 2011
+    "‒",   # 2012
+    "–",   # 2013
+    "—",   # 2014
+    "―",   # 2015
+    "−",   # 2212
+    "֊",   # 058A
+    "⁻",   # 207B
+    "₋",   # 208B
+    "⸺",  # 2E3A
+    "⸻",  # 2E3B
+    "﹘",  # FE58
+    "－",  # FF0D
+    "﹣",  # FE63
+)
+
+
+def _import_pymupdf():
+    try:
+        import pymupdf  # PyMuPDF >= 1.24
+        return pymupdf
+    except ImportError:
+        try:
+            import fitz  # older PyMuPDF exposes the module as `fitz`
+            return fitz
+        except ImportError as e:
+            raise ImportError(
+                "ebook2text requires the optional 'pymupdf' dependency. "
+                "Install it with: pip install pymupdf"
+            ) from e
+
 
 def ebook2text(path):
-    try:
-        doc = fitz.open(path)
-        n_pages = doc.page_count
-        
-        text = ""
-        
-        for p in range(n_pages):
-            text += doc.load_page(p).get_text()
-        
-        # Replace hyphen-newline to connect words
-        text = text.replace('-\n', '') # 002D
-        text = text.replace('‐\n', '') # 2010
-        text = text.replace('‑\n', '') # 2011
-        text = text.replace('‒\n', '') # 2012
-        text = text.replace('–\n', '') # 2013
-        text = text.replace('—\n', '') # 2014
-        text = text.replace('―\n', '') # 2015
-        text = text.replace('−\n', '') # 2212
-        text = text.replace('֊\n', '') # 058A
-        text = text.replace('⁻\n', '') # 207B
-        text = text.replace('₋\n', '') # 208B
-        text = text.replace('⸺\n', '') # 2E3A	
-        text = text.replace('⸻\n', '') # 2E3B	
-        text = text.replace('﹘\n', '') # FES8
-        text = text.replace('－\n', '') # FF0D	
-        text = text.replace('﹣\n', '') # FE63
+    """Extract and lightly clean text from the PDF / e-book at ``path``.
 
-        # Replace paragraph and random new lines
-        text = text.replace('\n', ' ')
+    Returns the extracted text, or a ``"Error: ..."`` string if extraction
+    fails. Raises :class:`ImportError` if PyMuPDF is not installed.
+    """
+    pymupdf = _import_pymupdf()
+
+    try:
+        doc = pymupdf.open(path)
+        text = "".join(
+            doc.load_page(p).get_text() for p in range(doc.page_count)
+        )
+
+        # Reconnect words split by a hyphen at a line break
+        for hyphen in _HYPHENS:
+            text = text.replace(hyphen + "\n", "")
+
+        # Flatten the remaining (paragraph / random) newlines
+        text = text.replace("\n", " ")
     except Exception as e:
-        return 'Error: ' + str(e)
+        return "Error: " + str(e)
 
     return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+# Tooling configuration only. Packaging still goes through setup.py.
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.coverage.run]
+source = ["anbani"]
+omit = ["anbani/data/*"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise ImportError",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-pymupdf==1.19.6
-hjson==3.0.2
-numpy==1.21.5
-pandas==1.4.2
-setuptools==61.2.0
-tqdm==4.64.0
+# Development environment. Equivalent to: pip install -e .[pdf,dev]
+hjson
+pymupdf
+pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,17 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     install_requires=[
-        "pymupdf",
         "hjson",
-        "numpy",
-        "pandas",
-        "tqdm",
     ],
+    extras_require={
+        "pdf": ["pymupdf"],          # ebook2text / PDF extraction
+        "dev": ["pytest", "pytest-cov"],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -1,0 +1,25 @@
+from anbani.nlp.contractions import cmap, expand, expand_text
+
+
+def test_cmap_loaded_from_csv():
+    # Sanity: the stdlib-csv loader produced the same mapping pandas did.
+    assert cmap["ა. შ."] == "ასე შემდეგ"
+    assert len(cmap) > 300
+
+
+def test_expand_known_contraction():
+    assert expand("ა. შ.") == "ასე შემდეგ"
+
+
+def test_expand_passthrough_unknown():
+    assert expand("არააბრევიატურა") == "არააბრევიატურა"
+
+
+def test_expand_text_replaces_contraction():
+    assert expand_text("ვნახოთ ა. შ.") == "ვნახოთ ასე შემდეგ"
+
+
+def test_expand_text_terminates_on_plain_text():
+    # Regression: the old [ა-ჿ]+\. loop spun forever on any Georgian word
+    # followed by a period that was not itself a contraction key.
+    assert expand_text("ეს მარტივი ტექსტია") == "ეს მარტივი ტექსტია"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,82 @@
+"""Tests for anbani.core.converter.
+
+The "golden" cases below are ported verbatim from the anbani.js test suite
+(test/index.test.mjs); both libraries share the same letters table, so the
+expected outputs must match exactly.
+"""
+
+import pytest
+
+import anbani
+from anbani.core.converter import classify_text
+
+
+# --- Golden cases shared with anbani.js -------------------------------------
+
+def test_unicameral_mkhedruli_to_asomtavruli():
+    assert anbani.convert("იყო არაბეთს როსტევან", "mkhedruli", "asomtavruli") == \
+        "ႨႷႭ ႠႰႠႡႤႧႱ ႰႭႱႲႤႥႠႬ"
+
+
+def test_unicameral_mkhedruli_to_mtavruli():
+    assert anbani.convert("ანბანი", "mkhedruli", "mtavruli") == "ᲐᲜᲑᲐᲜᲘ"
+
+
+def test_interpret_qwerty_to_mkhedruli():
+    # Regression: classify_text() reports 'latin', which must resolve to 'qwerty'
+    # instead of raising (previously an AssertionError).
+    assert anbani.interpret("iyo arabeTs rostevan", "mkhedruli") == \
+        "იყო არაბეთს როსტევან"
+
+
+def test_bicameral_shanidziseuli():
+    assert anbani.convert("ქართული ა'ნბანი", "mkhedruli", "shanidziseuli") == \
+        "Ⴕართული Ⴀნბანი"
+
+
+def test_bicameral_sasataure():
+    assert anbani.convert("ქართული ა'ნბანი", "mkhedruli", "sasataure") == \
+        "ႵᲐᲠᲗᲣᲚᲘ ႠᲜᲑᲐᲜᲘ"
+
+
+# --- Bug-fix regressions ----------------------------------------------------
+
+def test_empty_string_does_not_crash():
+    # Previously raised IndexError on text[0] in the bicameral path.
+    assert anbani.convert("", "mkhedruli", "sasataure") == ""
+    assert anbani.convert("", "mkhedruli", "mtavruli") == ""
+
+
+def test_unknown_source_raises_valueerror():
+    # Previously an AssertionError (and silently disabled under `python -O`).
+    with pytest.raises(ValueError):
+        anbani.convert("ანბანი", "klingon", "mtavruli")
+
+
+def test_unknown_target_raises_valueerror():
+    # Previously returned the input unchanged with no error.
+    with pytest.raises(ValueError):
+        anbani.convert("ანბანი", "mkhedruli", "klingon")
+
+
+def test_interpret_undetectable_raises_valueerror():
+    with pytest.raises(ValueError):
+        anbani.interpret("12345", "mtavruli")
+
+
+def test_classify_text_is_not_anchored():
+    # Regression for re.match -> re.search: leading non-letters must not hide
+    # the script.
+    assert classify_text("   რა ხდება") == "mkhedruli"
+    assert classify_text("'rostevan'") == "latin"
+
+
+def test_anbanismtavruli_back_compat_alias():
+    assert anbani.convert("ანბანი", "mkhedruli", "anbanismtavruli") == \
+        anbani.convert("ანბანი", "mkhedruli", "sasataure")
+
+
+def test_punctuation_maps_after_data_sync():
+    # The Python data table used to omit the punctuation rows, so '.' fell
+    # through unconverted. After syncing with data.mjs it maps to braille.
+    assert anbani.convert(".", "mkhedruli", "braille") == "⠲"

--- a/tests/test_georgianisation.py
+++ b/tests/test_georgianisation.py
@@ -1,0 +1,30 @@
+from anbani.nlp import georgianisation as g
+from anbani.nlp.georgianisation import georgianise, georgianise_fast, latinise
+
+
+def test_ambigrams_loaded_from_csv():
+    # The stdlib-csv loader must reproduce what pandas produced: every
+    # non-redundant row, in order. nc5_len7.csv has 8046 such rows.
+    assert len(g.ambigrams_balanced) == 8046
+    assert ("არtული>", "ართული>") in g.ambigrams_balanced
+
+
+def test_georgianise_fast_letters():
+    assert georgianise_fast("gamarjoba") == "გამარჯობა"
+
+
+def test_georgianise_fast_diphthongs():
+    assert georgianise_fast("sha") == "შა"
+    assert georgianise_fast("cha") == "ჩა"
+    assert georgianise_fast("dzma") == "ძმა"
+
+
+def test_georgianise_mode_dispatch():
+    assert georgianise("gamarjoba", mode="fast") == "გამარჯობა"
+    # Smarter modes use the ambigram tables; just assert they run and stay Georgian.
+    assert isinstance(georgianise("gamarjoba", mode="balanced"), str)
+    assert isinstance(georgianise("gamarjoba", mode="accurate"), str)
+
+
+def test_latinise_roundtrips_simple_word():
+    assert latinise("გამარჯობა") == "gamarjoba"

--- a/tests/test_nlp_utils.py
+++ b/tests/test_nlp_utils.py
@@ -1,0 +1,21 @@
+import importlib.util
+
+import pytest
+
+from anbani.nlp.utils import ebook2text
+
+_HAS_PYMUPDF = (
+    importlib.util.find_spec("pymupdf") is not None
+    or importlib.util.find_spec("fitz") is not None
+)
+
+
+@pytest.mark.skipif(not _HAS_PYMUPDF, reason="pymupdf not installed")
+def test_ebook2text_bad_path_returns_error_string():
+    assert ebook2text("definitely_does_not_exist.pdf").startswith("Error:")
+
+
+@pytest.mark.skipif(_HAS_PYMUPDF, reason="pymupdf is installed")
+def test_ebook2text_without_pymupdf_raises_importerror():
+    with pytest.raises(ImportError):
+        ebook2text("anything.pdf")

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+
+
+def test_public_api_is_exposed():
+    import anbani
+
+    assert callable(anbani.convert)
+    assert callable(anbani.interpret)
+    assert callable(anbani.classify_text)
+
+
+def test_import_is_lightweight():
+    # `import anbani` must not pull in heavy / optional dependencies. Run in a
+    # fresh interpreter so test-ordering can't pollute sys.modules.
+    code = (
+        "import anbani, sys; "
+        "assert 'pandas' not in sys.modules, 'pandas leaked'; "
+        "assert 'numpy' not in sys.modules, 'numpy leaked'; "
+        "assert 'pymupdf' not in sys.modules and 'fitz' not in sys.modules, 'pymupdf leaked'"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,38 @@
+from anbani.nlp.preprocessing import (
+    cleanup,
+    nested_tokenize_by_separators,
+    paragraph_tokenize,
+    sentence_tokenize,
+    word_tokenize,
+)
+
+
+def test_word_tokenize_strips_non_georgian():
+    assert word_tokenize("გამარჯობა, მსოფლიო!") == ["გამარჯობა", "მსოფლიო"]
+
+
+def test_word_tokenize_lowercases_mtavruli():
+    # str.lower() maps Mtavruli -> Mkhedruli
+    assert word_tokenize("ᲒᲐᲛᲐᲠᲯᲝᲑᲐ") == ["გამარჯობა"]
+
+
+def test_sentence_tokenize_nested():
+    assert sentence_tokenize("გ ა. ბ გ.") == [["გ", "ა"], ["ბ", "გ"]]
+
+
+def test_sentence_tokenize_question_and_exclamation_split():
+    # ? and ! are normalised to sentence terminators
+    assert sentence_tokenize("ა ბ! გ დ?") == [["ა", "ბ"], ["გ", "დ"]]
+
+
+def test_paragraph_tokenize_splits_on_newline():
+    assert paragraph_tokenize("გ ა\nბ გ") == [["გ", "ა"], ["ბ", "გ"]]
+
+
+def test_cleanup_collapses_whitespace_keeps_punctuation():
+    assert cleanup("გ,  ა!") == "გ, ა!"
+
+
+def test_nested_tokenize_is_separator_generic():
+    assert nested_tokenize_by_separators("a b\nc", "\n", " ") == [["a", "b"], ["c"]]
+    assert nested_tokenize_by_separators("", "\n", " ") == []


### PR DESCRIPTION
## What

Bug fixes and hardening for `anbani.core.converter`, plus a data-table resync with **anbani.js** and a first test/CI setup.

## Bugs fixed

| Issue | Before | After |
|---|---|---|
| `interpret()` on Latin/qwerty text | `classify_text` returns `'latin'`, which `convert()` rejected → **`AssertionError`** | `'latin'` resolves to `'qwerty'`; works |
| Input validation | `assert` (stripped under `python -O`, wrong exception type) | explicit `ValueError` |
| `classify_text()` | `re.match` — anchored at index 0, so leading space/quote/digit → `'unknown'` | `re.search` |
| Empty string in bicameral path | `IndexError` on `text[0]` | returns `""` |
| Regex `[A-z]` | also matches `` [ \ ] ^ _ ` `` | `[A-Za-z]` |
| `letter_converter` | bare `except:` (swallows everything) | `except ValueError` |
| `letters.js` file handle | never closed | `with open(...)` |
| Unknown target script | returned input unchanged, silently | `ValueError` |

## Data sync (single source of truth)

`anbani/data/letters.js` had silently drifted from `anbani.js/src/lib/data.mjs` despite the "exact copy" comment — Python was missing the punctuation rows, the **braille** script, and the real **titus** data. This PR makes it byte-identical again, so punctuation now maps correctly (e.g. `.` → `⠲`) and braille/titus are available.

## Naming

The asomtavruli-upper / mtavruli-lower bicameral script was called `anbanismtavruli` here but `sasataure` in anbani.js. Renamed to **`sasataure`** for cross-library consistency; `anbanismtavruli` kept as a back-compat alias.

## API

`convert` / `interpret` / `classify_text` are now exposed at the package root (`import anbani; anbani.convert(...)`). `nlp` is intentionally *not* imported there, so `import anbani` stays free of PyMuPDF/pandas/numpy.

## Tests / CI

Added a `pytest` suite — the five "golden" cases are ported verbatim from the anbani.js test suite (shared data table) — and a GitHub Actions workflow (this repo previously had no CI). The converter only needs `hjson`, so the workflow skips the heavy nlp deps for a fast, focused signal.

## Not in scope (follow-ups)

`nlp` dependency diet (drop pandas/numpy, lazy-import pymupdf), `pyproject.toml` migration, `nlp/__init__.py` cleanup.