### PR TITLE
nlp: add contract_text()

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ print(expand_text(text))
 
 ```
 
+Contract them back:
+
+```python
+from anbani.nlp.contractions import contract_text
+
+print(contract_text("მასის ატომური ერთეული და ასე შემდეგ"))
+
+# მ.ა.ე. და ა.შ.
+```
+
 ## To-Do
 
 Feel free to fork this repo!  

--- a/anbani/nlp/__init__.py
+++ b/anbani/nlp/__init__.py
@@ -4,5 +4,5 @@ Import the submodules directly, e.g.::
 
     from anbani.nlp.georgianisation import georgianise
     from anbani.nlp.preprocessing import word_tokenize
-    from anbani.nlp.contractions import expand_text
+    from anbani.nlp.contractions import expand_text, contract_text
 """

--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -24,3 +24,10 @@ def expand_text(text):
         if contraction in text:
             text = text.replace(contraction, cmap[contraction])
     return text
+
+
+def contract_text(text):
+    emap = {expansion: contraction for contraction, expansion in cmap.items()}
+    for expansion, contraction in emap.items():
+        text = text.replace(expansion, contraction)
+    return text

--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -11,10 +11,6 @@ with open(
 ) as _f:
     cmap = {row["CONTRACTION"]: row["EXPANSION"] for row in csv.DictReader(_f)}
 
-# Replace longest contractions first so that e.g. "ა.ს.ს.რ." is handled before
-# the shorter "ა." that it contains.
-_contractions_by_length = sorted(cmap.items(), key=lambda kv: len(kv[0]), reverse=True)
-
 
 def expand(word):
     # Just a wrapper around the contractions map
@@ -22,8 +18,9 @@ def expand(word):
 
 
 def expand_text(text):
-    # Replace every known contraction with its expansion.
-    for contraction, expansion in _contractions_by_length:
-        text = text.replace(contraction, expansion)
-
+    # Sort contractions by length (longest first) to avoid partial matches
+    sorted_contractions = sorted(cmap.keys(), key=len, reverse=True)
+    for contraction in sorted_contractions:
+        if contraction in text:
+            text = text.replace(contraction, cmap[contraction])
     return text

--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -11,6 +11,19 @@ with open(
 ) as _f:
     cmap = {row["CONTRACTION"]: row["EXPANSION"] for row in csv.DictReader(_f)}
 
+# Reverse direction (expansion -> contraction). Several contractions share one
+# expansion (e.g. "ა. შ." and "ა.შ." both expand to "ასე შემდეგ"); keep the
+# shortest contraction, with the string itself as a stable tie-break.
+emap = {}
+for _contraction, _expansion in cmap.items():
+    _incumbent = emap.get(_expansion)
+    if _incumbent is None or (len(_contraction), _contraction) < (len(_incumbent), _incumbent):
+        emap[_expansion] = _contraction
+
+# Some expansions are substrings of a longer expansion, so contract the longer
+# phrase first.
+_expansions_by_length = sorted(emap.items(), key=lambda kv: len(kv[0]), reverse=True)
+
 
 def expand(word):
     # Just a wrapper around the contractions map
@@ -26,8 +39,14 @@ def expand_text(text):
     return text
 
 
+def contract(phrase):
+    # Inverse of expand()
+    return emap.get(phrase, phrase)
+
+
 def contract_text(text):
-    emap = {expansion: contraction for contraction, expansion in cmap.items()}
-    for expansion, contraction in emap.items():
+    # Inverse of expand_text(): replace known expansions with their contraction,
+    # longest expansion first. Round-tripping expand_text() is not guaranteed.
+    for expansion, contraction in _expansions_by_length:
         text = text.replace(expansion, contraction)
     return text

--- a/anbani/nlp/contractions.py
+++ b/anbani/nlp/contractions.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import re
 from pathlib import Path
 
 module_path = Path(__file__).parent.parent.absolute()
@@ -11,18 +12,36 @@ with open(
 ) as _f:
     cmap = {row["CONTRACTION"]: row["EXPANSION"] for row in csv.DictReader(_f)}
 
-# Reverse direction (expansion -> contraction). Several contractions share one
-# expansion (e.g. "ა. შ." and "ა.შ." both expand to "ასე შემდეგ"); keep the
-# shortest contraction, with the string itself as a stable tie-break.
-emap = {}
-for _contraction, _expansion in cmap.items():
-    _incumbent = emap.get(_expansion)
-    if _incumbent is None or (len(_contraction), _contraction) < (len(_incumbent), _incumbent):
-        emap[_expansion] = _contraction
 
-# Some expansions are substrings of a longer expansion, so contract the longer
-# phrase first.
-_expansions_by_length = sorted(emap.items(), key=lambda kv: len(kv[0]), reverse=True)
+def _reverse_map(cmap):
+    # Expansion -> contraction. Several contractions share one expansion
+    # (e.g. "ა. შ." and "ა.შ." both expand to "ასე შემდეგ"); keep the shortest
+    # contraction, with the string itself as a stable tie-break.
+    emap = {}
+    for contraction, expansion in cmap.items():
+        incumbent = emap.get(expansion)
+        if incumbent is None or (len(contraction), contraction) < (len(incumbent), incumbent):
+            emap[expansion] = contraction
+    return emap
+
+
+emap = _reverse_map(cmap)
+
+
+def _replacer(mapping):
+    # Single-pass substitution: keys are matched longest-first (so "ა.ს.ს.რ."
+    # wins over its prefix "ა.") and only at Georgian word boundaries (so keys
+    # never fire inside a word, e.g. "ჰა" in "ჰაერი"). One pass also means an
+    # inserted replacement is never itself re-replaced.
+    keys = sorted(mapping, key=len, reverse=True)
+    pattern = re.compile(
+        "(?<![ა-ჿ])(?:" + "|".join(map(re.escape, keys)) + ")(?![ა-ჿ])"
+    )
+    return lambda text: pattern.sub(lambda m: mapping[m.group(0)], text)
+
+
+_expand_replacer = _replacer(cmap)
+_contract_replacer = _replacer(emap)
 
 
 def expand(word):
@@ -31,12 +50,8 @@ def expand(word):
 
 
 def expand_text(text):
-    # Sort contractions by length (longest first) to avoid partial matches
-    sorted_contractions = sorted(cmap.keys(), key=len, reverse=True)
-    for contraction in sorted_contractions:
-        if contraction in text:
-            text = text.replace(contraction, cmap[contraction])
-    return text
+    # Replace every known contraction with its expansion.
+    return _expand_replacer(text)
 
 
 def contract(phrase):
@@ -45,8 +60,6 @@ def contract(phrase):
 
 
 def contract_text(text):
-    # Inverse of expand_text(): replace known expansions with their contraction,
-    # longest expansion first. Round-tripping expand_text() is not guaranteed.
-    for expansion, contraction in _expansions_by_length:
-        text = text.replace(expansion, contraction)
-    return text
+    # Inverse of expand_text(): every known expansion is abbreviated, so prose
+    # that happens to contain one (e.g. a bare "ახალი") gets contracted too.
+    return _contract_replacer(text)

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -1,4 +1,10 @@
-from anbani.nlp.contractions import cmap, expand, expand_text
+from anbani.nlp.contractions import (
+    cmap,
+    contract,
+    contract_text,
+    expand,
+    expand_text,
+)
 
 
 def test_cmap_loaded_from_csv():
@@ -23,3 +29,21 @@ def test_expand_text_terminates_on_plain_text():
     # Regression: the old [ა-ჿ]+\. loop spun forever on any Georgian word
     # followed by a period that was not itself a contraction key.
     assert expand_text("ეს მარტივი ტექსტია") == "ეს მარტივი ტექსტია"
+
+
+def test_contract_known_expansion():
+    # Shared expansion resolves to the shortest contraction ("ა.შ." < "ა. შ.").
+    assert contract("ასე შემდეგ") == "ა.შ."
+
+
+def test_contract_passthrough_unknown():
+    assert contract("არააბრევიატურა") == "არააბრევიატურა"
+
+
+def test_contract_text_replaces_expansion():
+    assert contract_text("ვნახოთ ასე შემდეგ") == "ვნახოთ ა.შ."
+
+
+def test_contract_text_prefers_longest_expansion():
+    longest = max(cmap.values(), key=len)
+    assert contract_text(longest) == contract(longest)

--- a/tests/test_contractions.py
+++ b/tests/test_contractions.py
@@ -2,6 +2,7 @@ from anbani.nlp.contractions import (
     cmap,
     contract,
     contract_text,
+    emap,
     expand,
     expand_text,
 )
@@ -47,3 +48,34 @@ def test_contract_text_replaces_expansion():
 def test_contract_text_prefers_longest_expansion():
     longest = max(cmap.values(), key=len)
     assert contract_text(longest) == contract(longest)
+
+
+def test_expand_text_respects_word_boundaries():
+    # "ჰა" (-> "ჰექტარი") is the only dotless contraction key; it must fire as
+    # a standalone token but never inside a word.
+    assert expand_text("ჰაერი") == "ჰაერი"
+    assert expand_text("100 ჰა მიწა") == "100 ჰექტარი მიწა"
+
+
+def test_expand_text_does_not_rescan_replacements():
+    # Single-pass: an inserted expansion must not itself be re-expanded
+    # (e.g. the "ჰა" inside "ბუხჰალტერია").
+    assert expand_text("ბუხჰალტ.") == cmap["ბუხჰალტ."]
+
+
+def test_contract_text_respects_word_boundaries():
+    # "თავი" is an expansion, but it must not fire inside "თავისუფალი".
+    assert contract_text("თავისუფალი ქვეყანა") == "თავისუფალი ქვეყანა"
+
+
+def test_contract_text_matches_contract_for_every_expansion():
+    # Full invariant: contracting a bare expansion always yields exactly its
+    # contraction — catches chained-replacement bugs (e.g. "ათასწლეული" must
+    # become "ათასწ.", not "ათ.წ." via a second pass over the insertion).
+    for expansion, contraction in emap.items():
+        assert contract_text(expansion) == contraction
+
+
+def test_expand_text_matches_expand_for_every_contraction():
+    for contraction, expansion in cmap.items():
+        assert expand_text(contraction) == expansion


### PR DESCRIPTION
Adds `contract()` / `contract_text()` — the inverse of `expand()` / `expand_text()`.

- reverse map keeps the shortest contraction for shared expansions
- contracts the longest expansion first
- tests for both directions