### PR TITLE
3.0: drop unused 'start' table (paired w/ anbani.js)

### DIFF
--- a/anbani/data/letters.js
+++ b/anbani/data/letters.js
@@ -288,14 +288,6 @@ export default {
         // See also http://transliteration.eki.ee/pdf/Georgian.pdf
     },
 
-    start: {
-        mkhedruli: 4304,
-        mtavruli: 7312,
-        asomtavruli: 4256,
-        nuskhuri: 11520,
-        latin: 97
-    },
-
     regex: {
         mkhedruli: /[ა-ჿ]/,
         mtavruli: /[Ა-Ჿ]/,


### PR DESCRIPTION
Removes the dead `start:{}` table from `anbani/data/letters.js`, identically to anbani.js's `src/lib/data.mjs` (byte-identical, md5 `419530fd…`). Merge alongside the paired js PR.