### PR TITLE
3.0(5/n): parity CI (byte-identity guard)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,53 @@
+# Byte-identity guard for files shared with the sibling library anbani.js.
+# These files are copied verbatim between the two repos; this job fails if they
+# drift. For a coordinated change to a shared file (landing in both repos at
+# once), add the `parity-pending` label to skip this job while the pair is
+# in flight.
+name: parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'parity-pending') }}
+    steps:
+      - name: Checkout self (anbani.py)
+        uses: actions/checkout@v4
+        with:
+          path: self
+
+      - name: Checkout sibling (anbani.js default branch)
+        uses: actions/checkout@v4
+        with:
+          repository: Anbani/anbani.js
+          path: sibling
+
+      - name: Byte-compare shared files
+        shell: bash
+        run: |
+          # self path (this repo)  ->  sibling path (anbani.js)
+          pairs="
+          anbani/data/letters.js|src/lib/data.mjs
+          anbani/data/georgian_contractions.csv|data/georgian_contractions.csv
+          anbani/data/ambigram_nc5_len7.csv|data/ambigram_nc5_len7.csv
+          spec/golden.json|spec/golden.json
+          "
+          fail=0
+          while IFS='|' read -r a b; do
+            [ -z "$a" ] && continue
+            if [ ! -f "sibling/$b" ]; then
+              echo "::warning::sibling missing anbani.js:$b — skipping (bootstrap window)"
+              continue
+            fi
+            if cmp -s "self/$a" "sibling/$b"; then
+              echo "ok: $a == anbani.js:$b"
+            else
+              echo "::error::DRIFT: $a differs from anbani.js:$b"
+              fail=1
+            fi
+          done <<< "$pairs"
+          exit $fail


### PR DESCRIPTION
Final wave. Adds `.github/workflows/parity.yml`: checks out anbani.js's default branch and `cmp`s the four shared files (`letters.js`↔`data.mjs`, both CSVs, `spec/golden.json`). Fails on drift; `parity-pending` label skips it for coordinated changes. Born green.